### PR TITLE
Support filewatcher interval option

### DIFF
--- a/bin/machinegun
+++ b/bin/machinegun
@@ -2,4 +2,4 @@
 
 require_relative '../lib/machinegun'
 
-MachineGun.run(ENV["MACHINEGUN_INTERVAL"])
+MachineGun.run interval: ENV["MACHINEGUN_INTERVAL"]

--- a/bin/machinegun
+++ b/bin/machinegun
@@ -2,4 +2,4 @@
 
 require_relative '../lib/machinegun'
 
-MachineGun.run
+MachineGun.run(ENV["MACHINEGUN_INTERVAL"])

--- a/lib/machinegun.rb
+++ b/lib/machinegun.rb
@@ -2,27 +2,27 @@ require 'rack'
 require 'filewatcher'
 
 class MachineGun
-  
-  def self.run
+
+  def self.run(interval = nil)
     pid = start_server
-    
-    FileWatcher.new("./**/*.rb").watch do
+
+    FileWatcher.new("./**/*.rb").watch(interval || 0.5) do
       Process.kill "INT", pid
       Process.wait pid
-      
+
       pid = start_server
     end
   end
-  
+
   private
-  
+
   def self.start_server
     pid = fork do
       $0 = "rack"
       Rack::Server.start
     end
-    
+
     pid
   end
-  
+
 end

--- a/lib/machinegun.rb
+++ b/lib/machinegun.rb
@@ -2,27 +2,29 @@ require 'rack'
 require 'filewatcher'
 
 class MachineGun
-
-  def self.run(interval = nil)
+  
+  def self.run opts = {}
     pid = start_server
-
-    FileWatcher.new("./**/*.rb").watch(interval || 0.5) do
+     
+    interval = opts[:interval] || 0.5
+     
+    FileWatcher.new("./**/*.rb").watch interval do
       Process.kill "INT", pid
       Process.wait pid
-
+      
       pid = start_server
     end
   end
-
+  
   private
-
+  
   def self.start_server
     pid = fork do
       $0 = "rack"
       Rack::Server.start
     end
-
+    
     pid
   end
-
+  
 end


### PR DESCRIPTION
This PR introduces support for FileWatcher interval option keeping it backward compatible, the value is taken from the `ENV` from the bin script.
